### PR TITLE
added is_subset_opt

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -36,54 +36,54 @@ fn insert2(b: &mut Bencher) {
 
 #[bench]
 fn is_subset(b: &mut Bencher) {
-	let bitmap: RoaringBitmap<u32> = (1..250).collect();
-	b.iter(|| test::black_box(bitmap.is_subset(&bitmap)))
+    let bitmap: RoaringBitmap<u32> = (1..250).collect();
+    b.iter(|| test::black_box(bitmap.is_subset(&bitmap)))
 }
 
 #[bench]
 fn is_subset_2(b: &mut Bencher) {
-	let sub: RoaringBitmap<u32> = (1000..8196).collect();
-	let sup: RoaringBitmap<u32> = (0..16384).collect();
-	b.iter(|| test::black_box(sub.is_subset(&sup)))
+    let sub: RoaringBitmap<u32> = (1000..8196).collect();
+    let sup: RoaringBitmap<u32> = (0..16384).collect();
+    b.iter(|| test::black_box(sub.is_subset(&sup)))
 }
 
 #[bench]
 fn is_subset_3(b: &mut Bencher) {
-	let sub: RoaringBitmap<u32> = (1000..4096).map(|x| x * 2).collect();
-	let sup: RoaringBitmap<u32> = (0..16384).collect();
-	b.iter(|| test::black_box(sub.is_subset(&sup)))
+    let sub: RoaringBitmap<u32> = (1000..4096).map(|x| x * 2).collect();
+    let sup: RoaringBitmap<u32> = (0..16384).collect();
+    b.iter(|| test::black_box(sub.is_subset(&sup)))
 }
 
 #[bench]
 fn is_subset_4(b: &mut Bencher) {
-	let sub: RoaringBitmap<u32> = (0..17).map(|x| 1 << x).collect();
-	let sup: RoaringBitmap<u32> = (0..65536).collect();
-	b.iter(|| test::black_box(sub.is_subset(&sup)))
+    let sub: RoaringBitmap<u32> = (0..17).map(|x| 1 << x).collect();
+    let sup: RoaringBitmap<u32> = (0..65536).collect();
+    b.iter(|| test::black_box(sub.is_subset(&sup)))
 }
 
 #[bench]
 fn is_subset_opt(b: &mut Bencher) {
-	let bitmap: RoaringBitmap<u32> = (1..250).collect();
-	b.iter(|| test::black_box(bitmap.is_subset_opt(&bitmap)))
+    let bitmap: RoaringBitmap<u32> = (1..250).collect();
+    b.iter(|| test::black_box(bitmap.is_subset_opt(&bitmap)))
 }
 
 #[bench]
 fn is_subset_opt_2(b: &mut Bencher) {
-	let sub: RoaringBitmap<u32> = (1000..8196).collect();
-	let sup: RoaringBitmap<u32> = (0..16384).collect();
-	b.iter(|| test::black_box(sub.is_subset_opt(&sup)))
+    let sub: RoaringBitmap<u32> = (1000..8196).collect();
+    let sup: RoaringBitmap<u32> = (0..16384).collect();
+    b.iter(|| test::black_box(sub.is_subset_opt(&sup)))
 }
 
 #[bench]
 fn is_subset_opt_3(b: &mut Bencher) {
-	let sub: RoaringBitmap<u32> = (1000..4096).map(|x| x * 2).collect();
-	let sup: RoaringBitmap<u32> = (0..16384).collect();
-	b.iter(|| test::black_box(sub.is_subset_opt(&sup)))
+    let sub: RoaringBitmap<u32> = (1000..4096).map(|x| x * 2).collect();
+    let sup: RoaringBitmap<u32> = (0..16384).collect();
+    b.iter(|| test::black_box(sub.is_subset_opt(&sup)))
 }
 
 #[bench]
 fn is_subset_opt_4(b: &mut Bencher) {
-	let sub: RoaringBitmap<u32> = (0..17).map(|x| 1 << x).collect();
-	let sup: RoaringBitmap<u32> = (0..65536).collect();
-	b.iter(|| test::black_box(sub.is_subset_opt(&sup)))
+    let sub: RoaringBitmap<u32> = (0..17).map(|x| 1 << x).collect();
+    let sup: RoaringBitmap<u32> = (0..65536).collect();
+    b.iter(|| test::black_box(sub.is_subset_opt(&sup)))
 }

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -3,7 +3,6 @@
 extern crate test;
 extern crate roaring;
 
-use std::{ u32 };
 use test::Bencher;
 
 use roaring::RoaringBitmap;
@@ -11,7 +10,7 @@ use roaring::RoaringBitmap;
 #[bench]
 fn create(b: &mut Bencher) {
     b.iter(|| {
-        let mut bitmap: RoaringBitmap<u32> = RoaringBitmap::new();
+        let bitmap: RoaringBitmap<u32> = RoaringBitmap::new();
         bitmap
     })
 }
@@ -35,3 +34,56 @@ fn insert2(b: &mut Bencher) {
     })
 }
 
+#[bench]
+fn is_subset(b: &mut Bencher) {
+	let bitmap: RoaringBitmap<u32> = (1..250).collect();
+	b.iter(|| test::black_box(bitmap.is_subset(&bitmap)))
+}
+
+#[bench]
+fn is_subset_2(b: &mut Bencher) {
+	let sub: RoaringBitmap<u32> = (1000..8196).collect();
+	let sup: RoaringBitmap<u32> = (0..16384).collect();
+	b.iter(|| test::black_box(sub.is_subset(&sup)))
+}
+
+#[bench]
+fn is_subset_3(b: &mut Bencher) {
+	let sub: RoaringBitmap<u32> = (1000..4096).map(|x| x * 2).collect();
+	let sup: RoaringBitmap<u32> = (0..16384).collect();
+	b.iter(|| test::black_box(sub.is_subset(&sup)))
+}
+
+#[bench]
+fn is_subset_4(b: &mut Bencher) {
+	let sub: RoaringBitmap<u32> = (0..17).map(|x| 1 << x).collect();
+	let sup: RoaringBitmap<u32> = (0..65536).collect();
+	b.iter(|| test::black_box(sub.is_subset(&sup)))
+}
+
+#[bench]
+fn is_subset_opt(b: &mut Bencher) {
+	let bitmap: RoaringBitmap<u32> = (1..250).collect();
+	b.iter(|| test::black_box(bitmap.is_subset_opt(&bitmap)))
+}
+
+#[bench]
+fn is_subset_opt_2(b: &mut Bencher) {
+	let sub: RoaringBitmap<u32> = (1000..8196).collect();
+	let sup: RoaringBitmap<u32> = (0..16384).collect();
+	b.iter(|| test::black_box(sub.is_subset_opt(&sup)))
+}
+
+#[bench]
+fn is_subset_opt_3(b: &mut Bencher) {
+	let sub: RoaringBitmap<u32> = (1000..4096).map(|x| x * 2).collect();
+	let sup: RoaringBitmap<u32> = (0..16384).collect();
+	b.iter(|| test::black_box(sub.is_subset_opt(&sup)))
+}
+
+#[bench]
+fn is_subset_opt_4(b: &mut Bencher) {
+	let sub: RoaringBitmap<u32> = (0..17).map(|x| 1 << x).collect();
+	let sup: RoaringBitmap<u32> = (0..65536).collect();
+	b.iter(|| test::black_box(sub.is_subset_opt(&sup)))
+}

--- a/src/imp.rs
+++ b/src/imp.rs
@@ -1,5 +1,6 @@
 use std::iter::{ IntoIterator };
 use std::slice;
+use std::cmp::Ordering;
 
 use num::traits::{ Zero, Bounded };
 
@@ -89,6 +90,31 @@ pub fn is_subset<Size: ExtInt + Halveable>(this: &RB<Size>, other: &RB<Size>) ->
         (_, None) => return false,
         (Some(c1), Some(c2)) => c1.is_subset(c2),
     })
+}
+
+pub fn is_subset_opt<Size: ExtInt + Halveable>(this: &RB<Size>, other: &RB<Size>) -> bool {
+	let tv = &this.containers;
+	let ov = &other.containers;
+	let tlen = tv.len();
+	let olen = ov.len();
+	if tlen > olen { return false; }
+	let mut ti = 0;
+	let mut oi = 0;
+	loop {
+		let tc = &tv[ti];
+		let oc = &ov[oi];
+		match tc.key().cmp(&oc.key()) {
+			Ordering::Less => { return false; },
+			Ordering::Equal => { 
+				if !tc.is_subset(&oc) { return false; } 
+				ti += 1;
+				if ti >= tlen { return true; }
+			},
+			Ordering::Greater => (),
+		}
+		oi += 1;
+		if oi >= olen { return false }
+	}
 }
 
 #[inline]

--- a/src/imp.rs
+++ b/src/imp.rs
@@ -93,28 +93,28 @@ pub fn is_subset<Size: ExtInt + Halveable>(this: &RB<Size>, other: &RB<Size>) ->
 }
 
 pub fn is_subset_opt<Size: ExtInt + Halveable>(this: &RB<Size>, other: &RB<Size>) -> bool {
-	let tv = &this.containers;
-	let ov = &other.containers;
-	let tlen = tv.len();
-	let olen = ov.len();
-	if tlen > olen { return false; }
-	let mut ti = 0;
-	let mut oi = 0;
-	loop {
-		let tc = &tv[ti];
-		let oc = &ov[oi];
-		match tc.key().cmp(&oc.key()) {
-			Ordering::Less => { return false; },
-			Ordering::Equal => { 
-				if !tc.is_subset(&oc) { return false; } 
-				ti += 1;
-				if ti >= tlen { return true; }
-			},
-			Ordering::Greater => (),
-		}
-		oi += 1;
-		if oi >= olen { return false }
-	}
+    let tv = &this.containers;
+    let ov = &other.containers;
+    let tlen = tv.len();
+    let olen = ov.len();
+    if tlen > olen { return false; }
+    let mut ti = 0;
+    let mut oi = 0;
+    loop {
+        let tc = &tv[ti];
+        let oc = &ov[oi];
+        match tc.key().cmp(&oc.key()) {
+            Ordering::Less => { return false; },
+            Ordering::Equal => {
+                if !tc.is_subset(&oc) { return false; }
+                ti += 1;
+                if ti >= tlen { return true; }
+            },
+            Ordering::Greater => (),
+        }
+        oi += 1;
+        if oi >= olen { return false }
+    }
 }
 
 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,8 +249,8 @@ impl<Size: ExtInt + Halveable> RoaringBitmap<Size> {
         imp::is_subset(self, other)
     }
 
-	/// Returns `true` if this set is a subset of `other`.
-	#[inline]
+    /// Returns `true` if this set is a subset of `other`.
+    #[inline]
     pub fn is_subset_opt(&self, other: &Self) -> bool {
         imp::is_subset_opt(self, other)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,6 +249,12 @@ impl<Size: ExtInt + Halveable> RoaringBitmap<Size> {
         imp::is_subset(self, other)
     }
 
+	/// Returns `true` if this set is a subset of `other`.
+	#[inline]
+    pub fn is_subset_opt(&self, other: &Self) -> bool {
+        imp::is_subset_opt(self, other)
+    }
+
     /// Returns `true` if this set is a superset of `other`.
     ///
     /// # Examples

--- a/tests/is_subset.rs
+++ b/tests/is_subset.rs
@@ -6,6 +6,7 @@ fn array_not() {
     let sup: RoaringBitmap<u32> = (0..2000u32).collect();
     let sub: RoaringBitmap<u32> = (1000..3000u32).collect();
     assert_eq!(sub.is_subset(&sup), false);
+    assert_eq!(sub.is_subset_opt(&sup), false);
 }
 
 #[test]
@@ -13,6 +14,7 @@ fn array() {
     let sup: RoaringBitmap<u32> = (0..4000u32).collect();
     let sub: RoaringBitmap<u32> = (2000..3000u32).collect();
     assert_eq!(sub.is_subset(&sup), true);
+    assert_eq!(sub.is_subset_opt(&sup), true);
 }
 
 #[test]
@@ -20,6 +22,7 @@ fn array_bitmap_not() {
     let sup: RoaringBitmap<u32> = (0..2000u32).collect();
     let sub: RoaringBitmap<u32> = (1000..15000u32).collect();
     assert_eq!(sub.is_subset(&sup), false);
+    assert_eq!(sub.is_subset_opt(&sup), false);
 }
 
 #[test]
@@ -27,6 +30,7 @@ fn bitmap_not() {
     let sup: RoaringBitmap<u32> = (0..6000u32).collect();
     let sub: RoaringBitmap<u32> = (4000..10000u32).collect();
     assert_eq!(sub.is_subset(&sup), false);
+    assert_eq!(sub.is_subset_opt(&sup), false);
 }
 
 #[test]
@@ -34,6 +38,7 @@ fn bitmap() {
     let sup: RoaringBitmap<u32> = (0..20000u32).collect();
     let sub: RoaringBitmap<u32> = (5000..15000u32).collect();
     assert_eq!(sub.is_subset(&sup), true);
+    assert_eq!(sub.is_subset_opt(&sup), true);
 }
 
 #[test]
@@ -41,6 +46,7 @@ fn bitmap_array_not() {
     let sup: RoaringBitmap<u32> = (0..20000u32).collect();
     let sub: RoaringBitmap<u32> = (19000..21000u32).collect();
     assert_eq!(sub.is_subset(&sup), false);
+    assert_eq!(sub.is_subset_opt(&sup), false);
 }
 
 #[test]
@@ -48,6 +54,7 @@ fn bitmap_array() {
     let sup: RoaringBitmap<u32> = (0..20000u32).collect();
     let sub: RoaringBitmap<u32> = (18000..20000u32).collect();
     assert_eq!(sub.is_subset(&sup), true);
+    assert_eq!(sub.is_subset_opt(&sup), true);
 }
 
 #[test]
@@ -55,6 +62,7 @@ fn arrays_not() {
     let sup: RoaringBitmap<u32> = (0..2000u32).chain(1_000_000..1_002_000u32).collect();
     let sub: RoaringBitmap<u32> = (100_000..102_000u32).chain(1_100_000..1_102_000u32).collect();
     assert_eq!(sub.is_subset(&sup), false);
+    assert_eq!(sub.is_subset_opt(&sup), false);
 }
 
 #[test]
@@ -62,6 +70,7 @@ fn arrays() {
     let sup: RoaringBitmap<u32> = (0..3000u32).chain(100000..103000u32).collect();
     let sub: RoaringBitmap<u32> = (0..2000u32).chain(100000..102000u32).collect();
     assert_eq!(sub.is_subset(&sup), true);
+    assert_eq!(sub.is_subset_opt(&sup), true);
 }
 
 #[test]
@@ -69,6 +78,7 @@ fn bitmaps_not() {
     let sup: RoaringBitmap<u32> = (0..6000u32).chain(1000000..1006000u32).chain(2000000..2010000u32).collect();
     let sub: RoaringBitmap<u32> = (100000..106000u32).chain(1100000..1106000u32).collect();
     assert_eq!(sub.is_subset(&sup), false);
+    assert_eq!(sub.is_subset_opt(&sup), false);
 }
 
 #[test]
@@ -76,4 +86,5 @@ fn bitmaps() {
     let sup: RoaringBitmap<u32> = (0..1_000_000u32).chain(2_000_000..2_010_000u32).collect();
     let sub: RoaringBitmap<u32> = (0..10_000u32).chain(500_000..510_000u32).collect();
     assert_eq!(sub.is_subset(&sup), true);
+    assert_eq!(sub.is_subset_opt(&sup), true);
 }


### PR DESCRIPTION
This is a modestly optimized `is_subset` method. In my benchmarks, it gets:

```
test is_subset       ... bench:       1,170 ns/iter (+/- 1)
test is_subset_2     ... bench:       1,585 ns/iter (+/- 25)
test is_subset_3     ... bench:       4,863 ns/iter (+/- 8)
test is_subset_4     ... bench:          35 ns/iter (+/- 0)
test is_subset_opt   ... bench:       1,168 ns/iter (+/- 2)
test is_subset_opt_2 ... bench:       1,558 ns/iter (+/- 3)
test is_subset_opt_3 ... bench:       4,824 ns/iter (+/- 7)
test is_subset_opt_4 ... bench:           0 ns/iter (+/- 0)
```

So the wins are fairly small (depending on size), but I think it opens up possible future optimizations. Perhaps you want to replace `is_subset` completely? If so, leave a comment on this PR, and I can push another commit.

(Apart from that, fixed a few warnings)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/nemo157/roaring-rs/10)
<!-- Reviewable:end -->
