### PR TITLE
Add serialized_size(), bitmaps() and from_bitmaps()

### DIFF
--- a/src/bitmap/serialization.rs
+++ b/src/bitmap/serialization.rs
@@ -11,6 +11,24 @@ const SERIAL_COOKIE: u16 = 12347;
 // const NO_OFFSET_THRESHOLD: u8 = 4;
 
 impl RoaringBitmap {
+    /// Return the size in bytes of the serialized output.
+    /// This is compatible with the official C/C++, Java and Go implementations.
+    pub fn serialized_size(&self) -> usize {
+        let container_sizes: usize = self.containers.iter().map(|container| {
+            match container.store {
+                Store::Array(ref values) => {
+                    8 + values.len() * 2
+                }
+                Store::Bitmap(..) => {
+                    8 + 8 * 1024
+                }
+            }
+        }).sum();
+
+        // header + container sizes
+        8 + container_sizes
+    }
+
     /// Serialize this bitmap into [the standard Roaring on-disk format][format].
     /// This is compatible with the official C/C++, Java and Go implementations.
     ///

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -17,6 +17,7 @@ fn test_data_bitmap() -> RoaringBitmap {
 fn serialize_and_deserialize(bitmap: &RoaringBitmap) -> RoaringBitmap {
     let mut buffer = vec![];
     bitmap.serialize_into(&mut buffer).unwrap();
+    assert_eq!(buffer.len(), bitmap.serialized_size());
     RoaringBitmap::deserialize_from(&mut &buffer[..]).unwrap()
 }
 

--- a/tests/treemap_iter.rs
+++ b/tests/treemap_iter.rs
@@ -42,3 +42,13 @@ fn bitmaps() {
     assert_eq!(clone, original);
     assert_eq!(clone2, original);
 }
+
+#[test]
+fn bitmaps_iterator() {
+    let original = RoaringTreemap::from_iter((0..6000).chain(1000000..1012000).chain(2000000..2010000));
+    let clone = RoaringTreemap::from_bitmaps(original.bitmaps().map(|(p, b)| (p, b.clone())));
+    let clone2 = RoaringTreemap::from_iter(original.bitmaps().map(|(p, b)| (p, b.clone())));
+
+    assert_eq!(clone, original);
+    assert_eq!(clone2, original);
+}


### PR DESCRIPTION
Add serialized_size() is a great addition, we can bikeshed the name though. Constructing internals isn't terribly useful, but I really need it to manually serialize it (as there's no standard).