### PR TITLE
Format code using cargo fmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,10 @@ matrix:
     rust: stable
     install:
     - rustup component add clippy
+    - rustup component add rustfmt
     script:
     - cargo clippy --all-targets -- -D warnings
+    - cargo fmt -- --check
 
 branches:
   only: [staging, trying, master]

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -12,8 +12,7 @@ fn create(c: &mut Criterion) {
 }
 
 fn insert(c: &mut Criterion) {
-    c.bench_function(
-        "insert 1", |b| {
+    c.bench_function("insert 1", |b| {
         b.iter(|| {
             let mut bitmap = RoaringBitmap::new();
             bitmap.insert(1);
@@ -21,13 +20,12 @@ fn insert(c: &mut Criterion) {
         });
     });
 
-    c.bench_function(
-        "insert 2", |b| {
+    c.bench_function("insert 2", |b| {
         b.iter(|| {
             let mut bitmap = RoaringBitmap::new();
-        bitmap.insert(1);
-        bitmap.insert(2);
-        bitmap
+            bitmap.insert(1);
+            bitmap.insert(2);
+            bitmap
         });
     });
 }

--- a/src/bitmap/cmp.rs
+++ b/src/bitmap/cmp.rs
@@ -1,14 +1,20 @@
-use std::slice;
 use std::iter::Peekable;
+use std::slice;
 
-use crate::RoaringBitmap;
 use super::container::Container;
+use crate::RoaringBitmap;
 
-struct Pairs<'a>(Peekable<slice::Iter<'a, Container>>, Peekable<slice::Iter<'a, Container>>);
+struct Pairs<'a>(
+    Peekable<slice::Iter<'a, Container>>,
+    Peekable<slice::Iter<'a, Container>>,
+);
 
 impl RoaringBitmap {
     fn pairs<'a>(&'a self, other: &'a RoaringBitmap) -> Pairs<'a> {
-        Pairs(self.containers.iter().peekable(), other.containers.iter().peekable())
+        Pairs(
+            self.containers.iter().peekable(),
+            other.containers.iter().peekable(),
+        )
     }
 
     /// Returns true if the set has no elements in common with other. This is equivalent to
@@ -63,8 +69,14 @@ impl RoaringBitmap {
         for pair in self.pairs(other) {
             match pair {
                 (None, _) => (),
-                (_, None) => { return false; },
-                (Some(c1), Some(c2)) => if !c1.is_subset(c2) { return false; },
+                (_, None) => {
+                    return false;
+                }
+                (Some(c1), Some(c2)) => {
+                    if !c1.is_subset(c2) {
+                        return false;
+                    }
+                }
             }
         }
         true
@@ -101,7 +113,12 @@ impl<'a> Iterator for Pairs<'a> {
     type Item = (Option<&'a Container>, Option<&'a Container>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        enum Which { Left, Right, Both, None };
+        enum Which {
+            Left,
+            Right,
+            Both,
+            None,
+        };
         let which = match (self.0.peek(), self.1.peek()) {
             (None, None) => Which::None,
             (Some(_), None) => Which::Left,
@@ -111,7 +128,7 @@ impl<'a> Iterator for Pairs<'a> {
                 (key1, key2) if key1 < key2 => Which::Left,
                 (key1, key2) if key1 > key2 => Which::Right,
                 (_, _) => unreachable!(),
-            }
+            },
         };
         match which {
             Which::Left => Some((self.0.next(), None)),

--- a/src/bitmap/container.rs
+++ b/src/bitmap/container.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
+use super::store::{self, Store};
 use super::util;
-use super::store::{ self, Store };
 
 const ARRAY_LIMIT: u64 = 4096;
 
@@ -122,7 +122,7 @@ impl<'a> IntoIterator for &'a Container {
     fn into_iter(self) -> Iter<'a> {
         Iter {
             key: self.key,
-            inner: (&self.store).into_iter()
+            inner: (&self.store).into_iter(),
         }
     }
 }
@@ -134,7 +134,7 @@ impl IntoIterator for Container {
     fn into_iter(self) -> Iter<'static> {
         Iter {
             key: self.key,
-            inner: self.store.into_iter()
+            inner: self.store.into_iter(),
         }
     }
 }

--- a/src/bitmap/fmt.rs
+++ b/src/bitmap/fmt.rs
@@ -7,7 +7,13 @@ impl fmt::Debug for RoaringBitmap {
         if self.len() < 16 {
             write!(f, "RoaringBitmap<{:?}>", self.iter().collect::<Vec<u32>>())
         } else {
-            write!(f, "RoaringBitmap<{:?} values between {:?} and {:?}>", self.len(), self.min().unwrap(), self.max().unwrap())
+            write!(
+                f,
+                "RoaringBitmap<{:?} values between {:?} and {:?}>",
+                self.len(),
+                self.min().unwrap(),
+                self.max().unwrap()
+            )
         }
     }
 }

--- a/src/bitmap/inherent.rs
+++ b/src/bitmap/inherent.rs
@@ -1,7 +1,7 @@
 use crate::RoaringBitmap;
 
-use super::util;
 use super::container::Container;
+use super::util;
 use std::ops::Range;
 
 impl RoaringBitmap {
@@ -14,7 +14,9 @@ impl RoaringBitmap {
     /// let mut rb = RoaringBitmap::new();
     /// ```
     pub fn new() -> RoaringBitmap {
-        RoaringBitmap { containers: Vec::new() }
+        RoaringBitmap {
+            containers: Vec::new(),
+        }
     }
 
     /// Adds a value to the set. Returns `true` if the value was not already present in the set.
@@ -36,7 +38,7 @@ impl RoaringBitmap {
             Err(loc) => {
                 self.containers.insert(loc, Container::new(key));
                 &mut self.containers[loc]
-            },
+            }
         };
         container.insert(index)
     }
@@ -87,7 +89,10 @@ impl RoaringBitmap {
     /// assert_eq!(rb.remove_range(2..4), 2);
     /// ```
     pub fn remove_range(&mut self, range: Range<u64>) -> u64 {
-        assert!(range.end <= u64::from(u32::max_value()) + 1, "can't index past 2**32");
+        assert!(
+            range.end <= u64::from(u32::max_value()) + 1,
+            "can't index past 2**32"
+        );
         if range.start == range.end {
             return 0;
         }
@@ -114,8 +119,7 @@ impl RoaringBitmap {
                     result += self.containers[index].len;
                     self.containers.remove(index);
                     continue;
-                }
-                else {
+                } else {
                     result += self.containers[index].remove_range(a, b);
                     if self.containers[index].len == 0 {
                         self.containers.remove(index);
@@ -201,10 +205,7 @@ impl RoaringBitmap {
     /// assert_eq!(rb.len(), 2);
     /// ```
     pub fn len(&self) -> u64 {
-        self.containers
-            .iter()
-            .map(|container| container.len)
-            .sum()
+        self.containers.iter().map(|container| container.len).sum()
     }
 
     /// Returns the minimum value in the set (if the set is non-empty).
@@ -222,10 +223,10 @@ impl RoaringBitmap {
     /// assert_eq!(rb.min(), Some(3));
     /// ```
     pub fn min(&self) -> Option<u32> {
-        self.containers.first()
+        self.containers
+            .first()
             .map(|head| util::join(head.key, head.min()))
     }
-
 
     /// Returns the maximum value in the set (if the set is non-empty).
     ///
@@ -242,7 +243,8 @@ impl RoaringBitmap {
     /// assert_eq!(rb.max(), Some(4));
     /// ```
     pub fn max(&self) -> Option<u32> {
-        self.containers.last()
+        self.containers
+            .last()
             .map(|tail| util::join(tail.key, tail.max()))
     }
 }

--- a/src/bitmap/iter.rs
+++ b/src/bitmap/iter.rs
@@ -1,13 +1,17 @@
-use std::iter::{ self, FromIterator };
+use std::iter::{self, FromIterator};
 use std::slice;
 use std::vec;
 
-use crate::RoaringBitmap;
 use super::container::Container;
+use crate::RoaringBitmap;
 
 /// An iterator for `RoaringBitmap`.
 pub struct Iter<'a> {
-    inner: iter::FlatMap<slice::Iter<'a, Container>, &'a Container, fn(&'a Container) -> &'a Container>,
+    inner: iter::FlatMap<
+        slice::Iter<'a, Container>,
+        &'a Container,
+        fn(&'a Container) -> &'a Container,
+    >,
     size_hint: u64,
 }
 
@@ -19,7 +23,9 @@ pub struct IntoIter {
 
 impl<'a> Iter<'a> {
     fn new(containers: &[Container]) -> Iter {
-        fn identity<T>(t: T) -> T { t }
+        fn identity<T>(t: T) -> T {
+            t
+        }
         let size_hint = containers.iter().map(|c| c.len).sum();
         Iter {
             inner: containers.iter().flat_map(identity as _),
@@ -30,7 +36,9 @@ impl<'a> Iter<'a> {
 
 impl IntoIter {
     fn new(containers: Vec<Container>) -> IntoIter {
-        fn identity<T>(t: T) -> T { t }
+        fn identity<T>(t: T) -> T {
+            t
+        }
         let size_hint = containers.iter().map(|c| c.len).sum();
         IntoIter {
             inner: containers.into_iter().flat_map(identity as _),

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -1,18 +1,18 @@
-mod store;
 mod container;
-mod util;
 mod fmt;
+mod store;
+mod util;
 
 // Order of these modules matters as it determines the `impl` blocks order in
 // the docs
+mod cmp;
 mod inherent;
 mod iter;
 mod ops;
-mod cmp;
 mod serialization;
 
-pub use self::iter::Iter;
 pub use self::iter::IntoIter;
+pub use self::iter::Iter;
 
 /// A compressed bitmap using the [Roaring bitmap compression scheme](http://roaringbitmap.org).
 ///

--- a/src/bitmap/ops.rs
+++ b/src/bitmap/ops.rs
@@ -1,9 +1,4 @@
-use std::ops::{
-    BitAnd, BitAndAssign,
-    BitOr, BitOrAssign,
-    BitXor, BitXorAssign,
-    Sub, SubAssign
-};
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
 
 use crate::RoaringBitmap;
 
@@ -81,7 +76,9 @@ impl RoaringBitmap {
         while index < self.containers.len() {
             let key = self.containers[index].key;
             match other.containers.binary_search_by_key(&key, |c| c.key) {
-                Err(_) => { self.containers.remove(index); }
+                Err(_) => {
+                    self.containers.remove(index);
+                }
                 Ok(loc) => {
                     self.containers[index].intersect_with(&other.containers[loc]);
                     if self.containers[index].len == 0 {
@@ -135,8 +132,10 @@ impl RoaringBitmap {
                     } else {
                         index += 1;
                     }
-                },
-                _ => { index += 1; }
+                }
+                _ => {
+                    index += 1;
+                }
             }
         }
     }

--- a/src/bitmap/serialization.rs
+++ b/src/bitmap/serialization.rs
@@ -1,9 +1,9 @@
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::io;
-use byteorder::{ LittleEndian, ReadBytesExt, WriteBytesExt };
 
-use crate::RoaringBitmap;
-use super::store::Store;
 use super::container::Container;
+use super::store::Store;
+use crate::RoaringBitmap;
 
 const SERIAL_COOKIE_NO_RUNCONTAINER: u32 = 12346;
 const SERIAL_COOKIE: u16 = 12347;
@@ -27,16 +27,14 @@ impl RoaringBitmap {
     /// assert_eq!(rb1, rb2);
     /// ```
     pub fn serialized_size(&self) -> usize {
-        let container_sizes: usize = self.containers.iter().map(|container| {
-            match container.store {
-                Store::Array(ref values) => {
-                    8 + values.len() * 2
-                }
-                Store::Bitmap(..) => {
-                    8 + 8 * 1024
-                }
-            }
-        }).sum();
+        let container_sizes: usize = self
+            .containers
+            .iter()
+            .map(|container| match container.store {
+                Store::Array(ref values) => 8 + values.len() * 2,
+                Store::Bitmap(..) => 8 + 8 * 1024,
+            })
+            .sum();
 
         // header + container sizes
         8 + container_sizes
@@ -125,18 +123,18 @@ impl RoaringBitmap {
             } else if (cookie as u16) == SERIAL_COOKIE {
                 return Err(io::Error::new(
                     io::ErrorKind::Other,
-                    "run containers are unsupported"));
+                    "run containers are unsupported",
+                ));
             } else {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "unknown cookie value"));
+                return Err(io::Error::new(io::ErrorKind::Other, "unknown cookie value"));
             }
         };
 
         if size > u16::max_value() as usize {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
-                "size is greater than supported"));
+                "size is greater than supported",
+            ));
         }
 
         let mut description_bytes = vec![0u8; size * 4];

--- a/src/bitmap/util.rs
+++ b/src/bitmap/util.rs
@@ -10,7 +10,7 @@ pub fn join(high: u16, low: u16) -> u32 {
 
 #[cfg(test)]
 mod test {
-    use super::{ split, join };
+    use super::{join, split};
 
     #[test]
     fn test_split_u32() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 
 #![warn(missing_docs)]
 #![warn(variant_size_differences)]
-
 #![allow(unknown_lints)] // For clippy
 
 extern crate byteorder;

--- a/src/treemap/cmp.rs
+++ b/src/treemap/cmp.rs
@@ -4,8 +4,10 @@ use std::iter::Peekable;
 use crate::RoaringBitmap;
 use crate::RoaringTreemap;
 
-struct Pairs<'a>(Peekable<btree_map::Iter<'a, u32, RoaringBitmap>>,
-                 Peekable<btree_map::Iter<'a, u32, RoaringBitmap>>);
+struct Pairs<'a>(
+    Peekable<btree_map::Iter<'a, u32, RoaringBitmap>>,
+    Peekable<btree_map::Iter<'a, u32, RoaringBitmap>>,
+);
 
 impl RoaringTreemap {
     fn pairs<'a>(&'a self, other: &'a RoaringTreemap) -> Pairs<'a> {
@@ -118,14 +120,12 @@ impl<'a> Iterator for Pairs<'a> {
             (None, None) => Which::None,
             (Some(_), None) => Which::Left,
             (None, Some(_)) => Which::Right,
-            (Some(c1), Some(c2)) => {
-                match (c1.0, c2.0) {
-                    (key1, key2) if key1 == key2 => Which::Both,
-                    (key1, key2) if key1 < key2 => Which::Left,
-                    (key1, key2) if key1 > key2 => Which::Right,
-                    (_, _) => unreachable!(),
-                }
-            }
+            (Some(c1), Some(c2)) => match (c1.0, c2.0) {
+                (key1, key2) if key1 == key2 => Which::Both,
+                (key1, key2) if key1 < key2 => Which::Left,
+                (key1, key2) if key1 > key2 => Which::Right,
+                (_, _) => unreachable!(),
+            },
         };
         match which {
             Which::Left => Some((self.0.next().map(|e| e.1), None)),

--- a/src/treemap/fmt.rs
+++ b/src/treemap/fmt.rs
@@ -7,11 +7,13 @@ impl fmt::Debug for RoaringTreemap {
         if self.len() < 16 {
             write!(f, "RoaringTreemap<{:?}>", self.iter().collect::<Vec<u64>>())
         } else {
-            write!(f,
-                   "RoaringTreemap<{:?} values between {:?} and {:?}>",
-                   self.len(),
-                   self.min().unwrap(),
-                   self.max().unwrap())
+            write!(
+                f,
+                "RoaringTreemap<{:?} values between {:?} and {:?}>",
+                self.len(),
+                self.min().unwrap(),
+                self.max().unwrap()
+            )
         }
     }
 }

--- a/src/treemap/inherent.rs
+++ b/src/treemap/inherent.rs
@@ -1,10 +1,10 @@
-use crate::RoaringTreemap;
 use crate::RoaringBitmap;
+use crate::RoaringTreemap;
 
 use super::util;
-use std::ops::Range;
-use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
+use std::collections::BTreeMap;
+use std::ops::Range;
 
 impl RoaringTreemap {
     /// Creates an empty `RoaringTreemap`.
@@ -16,7 +16,9 @@ impl RoaringTreemap {
     /// let mut rb = RoaringTreemap::new();
     /// ```
     pub fn new() -> RoaringTreemap {
-        RoaringTreemap { map: BTreeMap::new() }
+        RoaringTreemap {
+            map: BTreeMap::new(),
+        }
     }
 
     /// Adds a value to the set. Returns `true` if the value was not already present in the set.
@@ -33,7 +35,10 @@ impl RoaringTreemap {
     /// ```
     pub fn insert(&mut self, value: u64) -> bool {
         let (hi, lo) = util::split(value);
-        self.map.entry(hi).or_insert_with(RoaringBitmap::new).insert(lo)
+        self.map
+            .entry(hi)
+            .or_insert_with(RoaringBitmap::new)
+            .insert(lo)
     }
 
     /// Removes a value from the set. Returns `true` if the value was present in the set.
@@ -62,7 +67,7 @@ impl RoaringTreemap {
                 } else {
                     false
                 }
-            },
+            }
         }
     }
 
@@ -174,9 +179,7 @@ impl RoaringTreemap {
     /// assert_eq!(rb.is_empty(), false);
     /// ```
     pub fn is_empty(&self) -> bool {
-        self.map
-            .values()
-            .all(RoaringBitmap::is_empty)
+        self.map.values().all(RoaringBitmap::is_empty)
     }
 
     /// Returns the number of distinct integers added to the set.
@@ -197,10 +200,7 @@ impl RoaringTreemap {
     /// assert_eq!(rb.len(), 2);
     /// ```
     pub fn len(&self) -> u64 {
-        self.map
-            .values()
-            .map(RoaringBitmap::len)
-            .sum()
+        self.map.values().map(RoaringBitmap::len).sum()
     }
 
     /// Returns the minimum value in the set (if the set is non-empty).
@@ -223,7 +223,6 @@ impl RoaringTreemap {
             .find(|&(_, rb)| rb.min().is_some())
             .map(|(k, rb)| util::join(*k, rb.min().unwrap()))
     }
-
 
     /// Returns the maximum value in the set (if the set is non-empty).
     ///

--- a/src/treemap/iter.rs
+++ b/src/treemap/iter.rs
@@ -1,10 +1,10 @@
-use std::collections::BTreeMap;
 use std::collections::btree_map;
+use std::collections::BTreeMap;
 use std::iter::{self, FromIterator};
 
-use crate::bitmap::Iter as Iter32;
-use crate::bitmap::IntoIter as IntoIter32;
 use super::util;
+use crate::bitmap::IntoIter as IntoIter32;
+use crate::bitmap::Iter as Iter32;
 use crate::RoaringBitmap;
 use crate::RoaringTreemap;
 
@@ -46,12 +46,16 @@ fn to64intoiter(t: (u32, RoaringBitmap)) -> To64IntoIter {
     }
 }
 
-type InnerIter<'a> = iter::FlatMap<btree_map::Iter<'a, u32, RoaringBitmap>,
-                                   To64Iter<'a>,
-                                   fn((&'a u32, &'a RoaringBitmap)) -> To64Iter<'a>>;
-type InnerIntoIter = iter::FlatMap<btree_map::IntoIter<u32, RoaringBitmap>,
-                                   To64IntoIter,
-                                   fn((u32, RoaringBitmap)) -> To64IntoIter>;
+type InnerIter<'a> = iter::FlatMap<
+    btree_map::Iter<'a, u32, RoaringBitmap>,
+    To64Iter<'a>,
+    fn((&'a u32, &'a RoaringBitmap)) -> To64Iter<'a>,
+>;
+type InnerIntoIter = iter::FlatMap<
+    btree_map::IntoIter<u32, RoaringBitmap>,
+    To64IntoIter,
+    fn((u32, RoaringBitmap)) -> To64IntoIter,
+>;
 
 /// An iterator for `RoaringTreemap`.
 pub struct Iter<'a> {
@@ -68,21 +72,18 @@ pub struct IntoIter {
 impl<'a> Iter<'a> {
     fn new(map: &BTreeMap<u32, RoaringBitmap>) -> Iter {
         let size_hint: u64 = map.iter().map(|(_, r)| r.len()).sum();
-        let i = map.iter()
-            .flat_map(to64iter as _);
+        let i = map.iter().flat_map(to64iter as _);
         Iter {
             inner: i,
             size_hint,
         }
-
     }
 }
 
 impl IntoIter {
     fn new(map: BTreeMap<u32, RoaringBitmap>) -> IntoIter {
         let size_hint = map.iter().map(|(_, r)| r.len()).sum();
-        let i = map.into_iter()
-            .flat_map(to64intoiter as _);
+        let i = map.into_iter().flat_map(to64intoiter as _);
         IntoIter {
             inner: i,
             size_hint,

--- a/src/treemap/mod.rs
+++ b/src/treemap/mod.rs
@@ -1,17 +1,17 @@
 use crate::RoaringBitmap;
 use std::collections::BTreeMap;
 
-mod util;
 mod fmt;
+mod util;
 
 // Order of these modules matters as it determines the `impl` blocks order in
 // the docs
+mod cmp;
 mod inherent;
 mod iter;
 mod ops;
-mod cmp;
 
-pub use self::iter::{Iter, IntoIter};
+pub use self::iter::{IntoIter, Iter};
 
 /// A compressed bitmap with u64 values.
 /// Implemented as a `BTreeMap` of `RoaringBitmap`s.

--- a/src/treemap/ops.rs
+++ b/src/treemap/ops.rs
@@ -1,5 +1,5 @@
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
 use std::collections::btree_map::Entry;
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
 
 use crate::RoaringTreemap;
 

--- a/src/treemap/util.rs
+++ b/src/treemap/util.rs
@@ -10,29 +10,77 @@ pub fn join(high: u32, low: u32) -> u64 {
 
 #[cfg(test)]
 mod test {
-    use super::{split, join};
+    use super::{join, split};
 
     #[test]
     fn test_split_u64() {
-        assert_eq!((0x0000_0000u32, 0x0000_0000u32), split(0x0000_0000_0000_0000u64));
-        assert_eq!((0x0000_0000u32, 0x0000_0001u32), split(0x0000_0000_0000_0001u64));
-        assert_eq!((0x0000_0000u32, 0xFFFF_FFFEu32), split(0x0000_0000_FFFF_FFFEu64));
-        assert_eq!((0x0000_0000u32, 0xFFFF_FFFFu32), split(0x0000_0000_FFFF_FFFFu64));
-        assert_eq!((0x0000_0001u32, 0x0000_0000u32), split(0x0000_0001_0000_0000u64));
-        assert_eq!((0x0000_0001u32, 0x0000_0001u32), split(0x0000_0001_0000_0001u64));
-        assert_eq!((0xFFFF_FFFFu32, 0xFFFF_FFFEu32), split(0xFFFF_FFFF_FFFF_FFFEu64));
-        assert_eq!((0xFFFF_FFFFu32, 0xFFFF_FFFFu32), split(0xFFFF_FFFF_FFFF_FFFFu64));
+        assert_eq!(
+            (0x0000_0000u32, 0x0000_0000u32),
+            split(0x0000_0000_0000_0000u64)
+        );
+        assert_eq!(
+            (0x0000_0000u32, 0x0000_0001u32),
+            split(0x0000_0000_0000_0001u64)
+        );
+        assert_eq!(
+            (0x0000_0000u32, 0xFFFF_FFFEu32),
+            split(0x0000_0000_FFFF_FFFEu64)
+        );
+        assert_eq!(
+            (0x0000_0000u32, 0xFFFF_FFFFu32),
+            split(0x0000_0000_FFFF_FFFFu64)
+        );
+        assert_eq!(
+            (0x0000_0001u32, 0x0000_0000u32),
+            split(0x0000_0001_0000_0000u64)
+        );
+        assert_eq!(
+            (0x0000_0001u32, 0x0000_0001u32),
+            split(0x0000_0001_0000_0001u64)
+        );
+        assert_eq!(
+            (0xFFFF_FFFFu32, 0xFFFF_FFFEu32),
+            split(0xFFFF_FFFF_FFFF_FFFEu64)
+        );
+        assert_eq!(
+            (0xFFFF_FFFFu32, 0xFFFF_FFFFu32),
+            split(0xFFFF_FFFF_FFFF_FFFFu64)
+        );
     }
 
     #[test]
     fn test_join_u64() {
-        assert_eq!(0x0000_0000_0000_0000u64, join(0x0000_0000u32, 0x0000_0000u32));
-        assert_eq!(0x0000_0000_0000_0001u64, join(0x0000_0000u32, 0x0000_0001u32));
-        assert_eq!(0x0000_0000_FFFF_FFFEu64, join(0x0000_0000u32, 0xFFFF_FFFEu32));
-        assert_eq!(0x0000_0000_FFFF_FFFFu64, join(0x0000_0000u32, 0xFFFF_FFFFu32));
-        assert_eq!(0x0000_0001_0000_0000u64, join(0x0000_0001u32, 0x0000_0000u32));
-        assert_eq!(0x0000_0001_0000_0001u64, join(0x0000_0001u32, 0x0000_0001u32));
-        assert_eq!(0xFFFF_FFFF_FFFF_FFFEu64, join(0xFFFF_FFFFu32, 0xFFFF_FFFEu32));
-        assert_eq!(0xFFFF_FFFF_FFFF_FFFFu64, join(0xFFFF_FFFFu32, 0xFFFF_FFFFu32));
+        assert_eq!(
+            0x0000_0000_0000_0000u64,
+            join(0x0000_0000u32, 0x0000_0000u32)
+        );
+        assert_eq!(
+            0x0000_0000_0000_0001u64,
+            join(0x0000_0000u32, 0x0000_0001u32)
+        );
+        assert_eq!(
+            0x0000_0000_FFFF_FFFEu64,
+            join(0x0000_0000u32, 0xFFFF_FFFEu32)
+        );
+        assert_eq!(
+            0x0000_0000_FFFF_FFFFu64,
+            join(0x0000_0000u32, 0xFFFF_FFFFu32)
+        );
+        assert_eq!(
+            0x0000_0001_0000_0000u64,
+            join(0x0000_0001u32, 0x0000_0000u32)
+        );
+        assert_eq!(
+            0x0000_0001_0000_0001u64,
+            join(0x0000_0001u32, 0x0000_0001u32)
+        );
+        assert_eq!(
+            0xFFFF_FFFF_FFFF_FFFEu64,
+            join(0xFFFF_FFFFu32, 0xFFFF_FFFEu32)
+        );
+        assert_eq!(
+            0xFFFF_FFFF_FFFF_FFFFu64,
+            join(0xFFFF_FFFFu32, 0xFFFF_FFFFu32)
+        );
     }
 }

--- a/tests/clone.rs
+++ b/tests/clone.rs
@@ -21,7 +21,11 @@ fn bitmap() {
 
 #[test]
 fn arrays() {
-    let original = RoaringBitmap::from_iter((0..2000).chain(1_000_000..1_002_000).chain(2_000_000..2_001_000));
+    let original = RoaringBitmap::from_iter(
+        (0..2000)
+            .chain(1_000_000..1_002_000)
+            .chain(2_000_000..2_001_000),
+    );
     let clone = original.clone();
 
     assert_eq!(clone, original);
@@ -29,7 +33,11 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let original = RoaringBitmap::from_iter((0..6000).chain(1_000_000..1_012_000).chain(2_000_000..2_010_000));
+    let original = RoaringBitmap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_012_000)
+            .chain(2_000_000..2_010_000),
+    );
     let clone = original.clone();
 
     assert_eq!(clone, original);

--- a/tests/difference_with.rs
+++ b/tests/difference_with.rs
@@ -81,8 +81,16 @@ fn bitmap_and_array_to_array() {
 
 #[test]
 fn arrays() {
-    let mut bitmap1 = RoaringBitmap::from_iter((0..2000).chain(1_000_000..1_002_000).chain(2_000_000..2_001_000));
-    let bitmap2 = RoaringBitmap::from_iter((1000..3000).chain(1_001_000..1_003_000).chain(2_000_000..2_001_000));
+    let mut bitmap1 = RoaringBitmap::from_iter(
+        (0..2000)
+            .chain(1_000_000..1_002_000)
+            .chain(2_000_000..2_001_000),
+    );
+    let bitmap2 = RoaringBitmap::from_iter(
+        (1000..3000)
+            .chain(1_001_000..1_003_000)
+            .chain(2_000_000..2_001_000),
+    );
     let bitmap3 = RoaringBitmap::from_iter((0..1000).chain(1_000_000..1_001_000));
 
     bitmap1.difference_with(&bitmap2);
@@ -92,8 +100,16 @@ fn arrays() {
 
 #[test]
 fn arrays_removing_one_whole_container() {
-    let mut bitmap1 = RoaringBitmap::from_iter((0..2000).chain(1_000_000..1_002_000).chain(2_000_000..2_001_000));
-    let bitmap2 = RoaringBitmap::from_iter((0..3000).chain(1_001_000..1_003_000).chain(2_000_000..2_001_000));
+    let mut bitmap1 = RoaringBitmap::from_iter(
+        (0..2000)
+            .chain(1_000_000..1_002_000)
+            .chain(2_000_000..2_001_000),
+    );
+    let bitmap2 = RoaringBitmap::from_iter(
+        (0..3000)
+            .chain(1_001_000..1_003_000)
+            .chain(2_000_000..2_001_000),
+    );
     let bitmap3 = RoaringBitmap::from_iter(1_000_000..1_001_000);
 
     bitmap1.difference_with(&bitmap2);
@@ -103,8 +119,16 @@ fn arrays_removing_one_whole_container() {
 
 #[test]
 fn bitmaps() {
-    let mut bitmap1 = RoaringBitmap::from_iter((0..6000).chain(1_000_000..1_012_000).chain(2_000_000..2_010_000));
-    let bitmap2 = RoaringBitmap::from_iter((3000..9000).chain(1_006_000..1_018_000).chain(2_000_000..2_010_000));
+    let mut bitmap1 = RoaringBitmap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_012_000)
+            .chain(2_000_000..2_010_000),
+    );
+    let bitmap2 = RoaringBitmap::from_iter(
+        (3000..9000)
+            .chain(1_006_000..1_018_000)
+            .chain(2_000_000..2_010_000),
+    );
     let bitmap3 = RoaringBitmap::from_iter((0..3000).chain(1_000_000..1_006_000));
 
     bitmap1.difference_with(&bitmap2);

--- a/tests/intersect_with.rs
+++ b/tests/intersect_with.rs
@@ -70,8 +70,16 @@ fn bitmap_and_array() {
 
 #[test]
 fn arrays() {
-    let mut bitmap1 = RoaringBitmap::from_iter((0..2000).chain(1_000_000..1_002_000).chain(3_000_000..3_001_000));
-    let bitmap2 = RoaringBitmap::from_iter((1000..3000).chain(1_001_000..1_003_000).chain(2_000_000..2_001_000));
+    let mut bitmap1 = RoaringBitmap::from_iter(
+        (0..2000)
+            .chain(1_000_000..1_002_000)
+            .chain(3_000_000..3_001_000),
+    );
+    let bitmap2 = RoaringBitmap::from_iter(
+        (1000..3000)
+            .chain(1_001_000..1_003_000)
+            .chain(2_000_000..2_001_000),
+    );
     let bitmap3 = RoaringBitmap::from_iter((1000..2000).chain(1_001_000..1_002_000));
 
     bitmap1.intersect_with(&bitmap2);
@@ -81,8 +89,16 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let mut bitmap1 = RoaringBitmap::from_iter((0..6000).chain(1_000_000..1_012_000).chain(3_000_000..3_010_000));
-    let bitmap2 = RoaringBitmap::from_iter((3000..9000).chain(1_006_000..1_018_000).chain(2_000_000..2_010_000));
+    let mut bitmap1 = RoaringBitmap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_012_000)
+            .chain(3_000_000..3_010_000),
+    );
+    let bitmap2 = RoaringBitmap::from_iter(
+        (3000..9000)
+            .chain(1_006_000..1_018_000)
+            .chain(2_000_000..2_010_000),
+    );
     let bitmap3 = RoaringBitmap::from_iter((3000..6000).chain(1_006_000..1_012_000));
 
     bitmap1.intersect_with(&bitmap2);

--- a/tests/is_disjoint.rs
+++ b/tests/is_disjoint.rs
@@ -33,28 +33,44 @@ fn bitmap_not() {
 
 #[test]
 fn arrays() {
-    let bitmap1 = RoaringBitmap::from_iter((0..2000).chain(1_000_000..1_002_000).chain(2_000_000..2_002_000));
+    let bitmap1 = RoaringBitmap::from_iter(
+        (0..2000)
+            .chain(1_000_000..1_002_000)
+            .chain(2_000_000..2_002_000),
+    );
     let bitmap2 = RoaringBitmap::from_iter((100_000..102_000).chain(1_100_000..1_102_000));
     assert_eq!(bitmap1.is_disjoint(&bitmap2), true);
 }
 
 #[test]
 fn arrays_not() {
-    let bitmap1 = RoaringBitmap::from_iter((0..2_000).chain(1_000_000..1_002_000).chain(2_000_000..2_002_000));
+    let bitmap1 = RoaringBitmap::from_iter(
+        (0..2_000)
+            .chain(1_000_000..1_002_000)
+            .chain(2_000_000..2_002_000),
+    );
     let bitmap2 = RoaringBitmap::from_iter((100_000..102_000).chain(1_001_000..1_003_000));
     assert_eq!(bitmap1.is_disjoint(&bitmap2), false);
 }
 
 #[test]
 fn bitmaps() {
-    let bitmap1 = RoaringBitmap::from_iter((0..6000).chain(1_000_000..1_006_000).chain(2_000_000..2_006_000));
+    let bitmap1 = RoaringBitmap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_006_000)
+            .chain(2_000_000..2_006_000),
+    );
     let bitmap2 = RoaringBitmap::from_iter((100_000..106_000).chain(1_100_000..1_106_000));
     assert_eq!(bitmap1.is_disjoint(&bitmap2), true);
 }
 
 #[test]
 fn bitmaps_not() {
-    let bitmap1 = RoaringBitmap::from_iter((0..6000).chain(1_000_000..1_006_000).chain(2_000_000..2_006_000));
+    let bitmap1 = RoaringBitmap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_006_000)
+            .chain(2_000_000..2_006_000),
+    );
     let bitmap2 = RoaringBitmap::from_iter((100_000..106_000).chain(1_004_000..1_008_000));
     assert_eq!(bitmap1.is_disjoint(&bitmap2), false);
 }

--- a/tests/is_subset.rs
+++ b/tests/is_subset.rs
@@ -68,7 +68,11 @@ fn arrays() {
 
 #[test]
 fn bitmaps_not() {
-    let sup = RoaringBitmap::from_iter((0..6000).chain(1_000_000..1_006_000).chain(2_000_000..2_010_000));
+    let sup = RoaringBitmap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_006_000)
+            .chain(2_000_000..2_010_000),
+    );
     let sub = RoaringBitmap::from_iter((100_000..106_000).chain(1_100_000..1_106_000));
     assert_eq!(sub.is_subset(&sup), false);
 }

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -25,7 +25,11 @@ fn bitmap() {
 
 #[test]
 fn arrays() {
-    let original = RoaringBitmap::from_iter((0..2000).chain(1_000_000..1_002_000).chain(2_000_000..2_001_000));
+    let original = RoaringBitmap::from_iter(
+        (0..2000)
+            .chain(1_000_000..1_002_000)
+            .chain(2_000_000..2_001_000),
+    );
     let clone = RoaringBitmap::from_iter(&original);
     let clone2 = RoaringBitmap::from_iter(original.clone());
 
@@ -35,7 +39,11 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let original = RoaringBitmap::from_iter((0..6000).chain(1_000_000..1_012_000).chain(2_000_000..2_010_000));
+    let original = RoaringBitmap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_012_000)
+            .chain(2_000_000..2_010_000),
+    );
     let clone = RoaringBitmap::from_iter(&original);
     let clone2 = RoaringBitmap::from_iter(original.clone());
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -37,11 +37,27 @@ fn smoke() {
 
 #[test]
 fn remove_range() {
-    let ranges = [0u32, 1, 63, 64, 65, 100, 4096 - 1, 4096, 4096 + 1, 65536 - 1, 65536, 65536 + 1];
+    let ranges = [
+        0u32,
+        1,
+        63,
+        64,
+        65,
+        100,
+        4096 - 1,
+        4096,
+        4096 + 1,
+        65536 - 1,
+        65536,
+        65536 + 1,
+    ];
     for (i, &a) in ranges.iter().enumerate() {
         for &b in &ranges[i..] {
             let mut bitmap = RoaringBitmap::from_iter(0..=65536);
-            assert_eq!(bitmap.remove_range(u64::from(a)..u64::from(b)), u64::from(b - a));
+            assert_eq!(
+                bitmap.remove_range(u64::from(a)..u64::from(b)),
+                u64::from(b - a)
+            );
             assert_eq!(bitmap, RoaringBitmap::from_iter((0..a).chain(b..=65536)));
         }
     }

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -9,9 +9,11 @@ static BITMAP_WITHOUT_RUNS: &[u8] = include_bytes!("bitmapwithoutruns.bin");
 
 fn test_data_bitmap() -> RoaringBitmap {
     RoaringBitmap::from_iter(
-        (0..100).map(|i| i * 1000)
+        (0..100)
+            .map(|i| i * 1000)
             .chain((100_000..200_000).map(|i| i * 3))
-            .chain(700_000..800_000))
+            .chain(700_000..800_000),
+    )
 }
 
 fn serialize_and_deserialize(bitmap: &RoaringBitmap) -> RoaringBitmap {
@@ -25,7 +27,8 @@ fn serialize_and_deserialize(bitmap: &RoaringBitmap) -> RoaringBitmap {
 fn test_deserialize_from_provided_data() {
     assert_eq!(
         RoaringBitmap::deserialize_from(&mut &BITMAP_WITHOUT_RUNS[..]).unwrap(),
-        test_data_bitmap());
+        test_data_bitmap()
+    );
 }
 
 #[test]

--- a/tests/size_hint.rs
+++ b/tests/size_hint.rs
@@ -27,7 +27,11 @@ fn bitmap() {
 
 #[test]
 fn arrays() {
-    let bitmap = RoaringBitmap::from_iter((0..2000).chain(1_000_000..1_002_000).chain(2_000_000..2_001_000));
+    let bitmap = RoaringBitmap::from_iter(
+        (0..2000)
+            .chain(1_000_000..1_002_000)
+            .chain(2_000_000..2_001_000),
+    );
     let mut iter = bitmap.iter();
     assert_eq!((5000, Some(5000)), iter.size_hint());
     iter.by_ref().take(3000).for_each(drop);
@@ -38,7 +42,11 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let bitmap = RoaringBitmap::from_iter((0..6000).chain(1_000_000..1_012_000).chain(2_000_000..2_010_000));
+    let bitmap = RoaringBitmap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_012_000)
+            .chain(2_000_000..2_010_000),
+    );
     let mut iter = bitmap.iter();
     assert_eq!((28000, Some(28000)), iter.size_hint());
     iter.by_ref().take(2000).for_each(drop);

--- a/tests/symmetric_difference_with.rs
+++ b/tests/symmetric_difference_with.rs
@@ -81,9 +81,24 @@ fn bitmap_and_array_to_array() {
 
 #[test]
 fn arrays() {
-    let mut bitmap1 = RoaringBitmap::from_iter((0..2000).chain(1_000_000..1_002_000).chain(3_000_000..3_001_000));
-    let bitmap2 = RoaringBitmap::from_iter((1000..3000).chain(1_001_000..1_003_000).chain(2_000_000..2_000_001));
-    let bitmap3 = RoaringBitmap::from_iter((0..1000).chain(1_000_000..1_001_000).chain(2000..3000).chain(1_002_000..1_003_000).chain(2_000_000..2_000_001).chain(3_000_000..3_001_000));
+    let mut bitmap1 = RoaringBitmap::from_iter(
+        (0..2000)
+            .chain(1_000_000..1_002_000)
+            .chain(3_000_000..3_001_000),
+    );
+    let bitmap2 = RoaringBitmap::from_iter(
+        (1000..3000)
+            .chain(1_001_000..1_003_000)
+            .chain(2_000_000..2_000_001),
+    );
+    let bitmap3 = RoaringBitmap::from_iter(
+        (0..1000)
+            .chain(1_000_000..1_001_000)
+            .chain(2000..3000)
+            .chain(1_002_000..1_003_000)
+            .chain(2_000_000..2_000_001)
+            .chain(3_000_000..3_001_000),
+    );
 
     bitmap1.symmetric_difference_with(&bitmap2);
 
@@ -92,9 +107,24 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let mut bitmap1 = RoaringBitmap::from_iter((0..6000).chain(1_000_000..1_012_000).chain(3_000_000..3_010_000));
-    let bitmap2 = RoaringBitmap::from_iter((3000..7000).chain(1_006_000..1_018_000).chain(2_000_000..2_010_000));
-    let bitmap3 = RoaringBitmap::from_iter((0..3000).chain(1_000_000..1_006_000).chain(6000..7000).chain(1_012_000..1_018_000).chain(2_000_000..2_010_000).chain(3_000_000..3_010_000));
+    let mut bitmap1 = RoaringBitmap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_012_000)
+            .chain(3_000_000..3_010_000),
+    );
+    let bitmap2 = RoaringBitmap::from_iter(
+        (3000..7000)
+            .chain(1_006_000..1_018_000)
+            .chain(2_000_000..2_010_000),
+    );
+    let bitmap3 = RoaringBitmap::from_iter(
+        (0..3000)
+            .chain(1_000_000..1_006_000)
+            .chain(6000..7000)
+            .chain(1_012_000..1_018_000)
+            .chain(2_000_000..2_010_000)
+            .chain(3_000_000..3_010_000),
+    );
 
     bitmap1.symmetric_difference_with(&bitmap2);
 

--- a/tests/treemap_clone.rs
+++ b/tests/treemap_clone.rs
@@ -21,7 +21,11 @@ fn bitmap() {
 
 #[test]
 fn arrays() {
-    let original = RoaringTreemap::from_iter((0..2000).chain(1_000_000..1_002_000).chain(2_000_000..2_001_000));
+    let original = RoaringTreemap::from_iter(
+        (0..2000)
+            .chain(1_000_000..1_002_000)
+            .chain(2_000_000..2_001_000),
+    );
     let clone = original.clone();
 
     assert_eq!(clone, original);
@@ -29,7 +33,11 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let original = RoaringTreemap::from_iter((0..6000).chain(1_000_000..1_012_000).chain(2_000_000..2_010_000));
+    let original = RoaringTreemap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_012_000)
+            .chain(2_000_000..2_010_000),
+    );
     let clone = original.clone();
 
     assert_eq!(clone, original);

--- a/tests/treemap_difference_with.rs
+++ b/tests/treemap_difference_with.rs
@@ -81,8 +81,16 @@ fn bitmap_and_array_to_array() {
 
 #[test]
 fn arrays() {
-    let mut bitmap1 = RoaringTreemap::from_iter((0..2000).chain(1_000_000..1_002_000).chain(2_000_000..2_001_000));
-    let bitmap2 = RoaringTreemap::from_iter((1000..3000).chain(1_001_000..1_003_000).chain(2_000_000..2_001_000));
+    let mut bitmap1 = RoaringTreemap::from_iter(
+        (0..2000)
+            .chain(1_000_000..1_002_000)
+            .chain(2_000_000..2_001_000),
+    );
+    let bitmap2 = RoaringTreemap::from_iter(
+        (1000..3000)
+            .chain(1_001_000..1_003_000)
+            .chain(2_000_000..2_001_000),
+    );
     let bitmap3 = RoaringTreemap::from_iter((0..1000).chain(1_000_000..1_001_000));
 
     bitmap1.difference_with(&bitmap2);
@@ -92,8 +100,16 @@ fn arrays() {
 
 #[test]
 fn arrays_removing_one_whole_container() {
-    let mut bitmap1 = RoaringTreemap::from_iter((0..2000).chain(1_000_000..1_002_000).chain(2_000_000..2_001_000));
-    let bitmap2 = RoaringTreemap::from_iter((0..3000).chain(1_001_000..1_003_000).chain(2_000_000..2_001_000));
+    let mut bitmap1 = RoaringTreemap::from_iter(
+        (0..2000)
+            .chain(1_000_000..1_002_000)
+            .chain(2_000_000..2_001_000),
+    );
+    let bitmap2 = RoaringTreemap::from_iter(
+        (0..3000)
+            .chain(1_001_000..1_003_000)
+            .chain(2_000_000..2_001_000),
+    );
     let bitmap3 = RoaringTreemap::from_iter(1_000_000..1_001_000);
 
     bitmap1.difference_with(&bitmap2);
@@ -103,8 +119,16 @@ fn arrays_removing_one_whole_container() {
 
 #[test]
 fn bitmaps() {
-    let mut bitmap1 = RoaringTreemap::from_iter((0..6000).chain(1_000_000..1_012_000).chain(2_000_000..2_010_000));
-    let bitmap2 = RoaringTreemap::from_iter((3000..9000).chain(1_006_000..1_018_000).chain(2_000_000..2_010_000));
+    let mut bitmap1 = RoaringTreemap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_012_000)
+            .chain(2_000_000..2_010_000),
+    );
+    let bitmap2 = RoaringTreemap::from_iter(
+        (3000..9000)
+            .chain(1_006_000..1_018_000)
+            .chain(2_000_000..2_010_000),
+    );
     let bitmap3 = RoaringTreemap::from_iter((0..3000).chain(1_000_000..1_006_000));
 
     bitmap1.difference_with(&bitmap2);

--- a/tests/treemap_intersect_with.rs
+++ b/tests/treemap_intersect_with.rs
@@ -70,8 +70,16 @@ fn bitmap_and_array() {
 
 #[test]
 fn arrays() {
-    let mut bitmap1 = RoaringTreemap::from_iter((0..2000).chain(1_000_000..1_002_000).chain(3_000_000..3_001_000));
-    let bitmap2 = RoaringTreemap::from_iter((1000..3000).chain(1_001_000..1_003_000).chain(2_000_000..2_001_000));
+    let mut bitmap1 = RoaringTreemap::from_iter(
+        (0..2000)
+            .chain(1_000_000..1_002_000)
+            .chain(3_000_000..3_001_000),
+    );
+    let bitmap2 = RoaringTreemap::from_iter(
+        (1000..3000)
+            .chain(1_001_000..1_003_000)
+            .chain(2_000_000..2_001_000),
+    );
     let bitmap3 = RoaringTreemap::from_iter((1000..2000).chain(1_001_000..1_002_000));
 
     bitmap1.intersect_with(&bitmap2);
@@ -81,8 +89,16 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let mut bitmap1 = RoaringTreemap::from_iter((0..6000).chain(1_000_000..1_012_000).chain(3_000_000..3_010_000));
-    let bitmap2 = RoaringTreemap::from_iter((3000..9000).chain(1_006_000..1_018_000).chain(2_000_000..2_010_000));
+    let mut bitmap1 = RoaringTreemap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_012_000)
+            .chain(3_000_000..3_010_000),
+    );
+    let bitmap2 = RoaringTreemap::from_iter(
+        (3000..9000)
+            .chain(1_006_000..1_018_000)
+            .chain(2_000_000..2_010_000),
+    );
     let bitmap3 = RoaringTreemap::from_iter((3000..6000).chain(1_006_000..1_012_000));
 
     bitmap1.intersect_with(&bitmap2);

--- a/tests/treemap_is_disjoint.rs
+++ b/tests/treemap_is_disjoint.rs
@@ -33,28 +33,44 @@ fn bitmap_not() {
 
 #[test]
 fn arrays() {
-    let bitmap1 = RoaringTreemap::from_iter((0..2000).chain(1_000_000..1_002_000).chain(2_000_000..2_002_000));
+    let bitmap1 = RoaringTreemap::from_iter(
+        (0..2000)
+            .chain(1_000_000..1_002_000)
+            .chain(2_000_000..2_002_000),
+    );
     let bitmap2 = RoaringTreemap::from_iter((100_000..102_000).chain(1_100_000..1_102_000));
     assert_eq!(bitmap1.is_disjoint(&bitmap2), true);
 }
 
 #[test]
 fn arrays_not() {
-    let bitmap1 = RoaringTreemap::from_iter((0..2_000).chain(1_000_000..1_002_000).chain(2_000_000..2_002_000));
+    let bitmap1 = RoaringTreemap::from_iter(
+        (0..2_000)
+            .chain(1_000_000..1_002_000)
+            .chain(2_000_000..2_002_000),
+    );
     let bitmap2 = RoaringTreemap::from_iter((100_000..102_000).chain(1_001_000..1_003_000));
     assert_eq!(bitmap1.is_disjoint(&bitmap2), false);
 }
 
 #[test]
 fn bitmaps() {
-    let bitmap1 = RoaringTreemap::from_iter((0..6000).chain(1_000_000..1_006_000).chain(2_000_000..2_006_000));
+    let bitmap1 = RoaringTreemap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_006_000)
+            .chain(2_000_000..2_006_000),
+    );
     let bitmap2 = RoaringTreemap::from_iter((100_000..106_000).chain(1_100_000..1_106_000));
     assert_eq!(bitmap1.is_disjoint(&bitmap2), true);
 }
 
 #[test]
 fn bitmaps_not() {
-    let bitmap1 = RoaringTreemap::from_iter((0..6000).chain(1_000_000..1_006_000).chain(2_000_000..2_006_000));
+    let bitmap1 = RoaringTreemap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_006_000)
+            .chain(2_000_000..2_006_000),
+    );
     let bitmap2 = RoaringTreemap::from_iter((100_000..106_000).chain(1_004_000..1_008_000));
     assert_eq!(bitmap1.is_disjoint(&bitmap2), false);
 }

--- a/tests/treemap_is_subset.rs
+++ b/tests/treemap_is_subset.rs
@@ -68,7 +68,11 @@ fn arrays() {
 
 #[test]
 fn bitmaps_not() {
-    let sup = RoaringTreemap::from_iter((0..6000).chain(1_000_000..1_006_000).chain(2_000_000..2_010_000));
+    let sup = RoaringTreemap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_006_000)
+            .chain(2_000_000..2_010_000),
+    );
     let sub = RoaringTreemap::from_iter((100_000..106_000).chain(1_100_000..1_106_000));
     assert_eq!(sub.is_subset(&sup), false);
 }

--- a/tests/treemap_iter.rs
+++ b/tests/treemap_iter.rs
@@ -25,7 +25,11 @@ fn bitmap() {
 
 #[test]
 fn arrays() {
-    let original = RoaringTreemap::from_iter((0..2000).chain(1_000_000..1_002_000).chain(2_000_000..2_001_000));
+    let original = RoaringTreemap::from_iter(
+        (0..2000)
+            .chain(1_000_000..1_002_000)
+            .chain(2_000_000..2_001_000),
+    );
     let clone = RoaringTreemap::from_iter(&original);
     let clone2 = RoaringTreemap::from_iter(original.clone());
 
@@ -35,7 +39,11 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let original = RoaringTreemap::from_iter((0..6000).chain(1_000_000..1_012_000).chain(2_000_000..2_010_000));
+    let original = RoaringTreemap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_012_000)
+            .chain(2_000_000..2_010_000),
+    );
     let clone = RoaringTreemap::from_iter(&original);
     let clone2 = RoaringTreemap::from_iter(original.clone());
 
@@ -45,7 +53,11 @@ fn bitmaps() {
 
 #[test]
 fn bitmaps_iterator() {
-    let original = RoaringTreemap::from_iter((0..6000).chain(1_000_000..1_012_000).chain(2_000_000..2_010_000));
+    let original = RoaringTreemap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_012_000)
+            .chain(2_000_000..2_010_000),
+    );
     let clone = RoaringTreemap::from_bitmaps(original.bitmaps().map(|(p, b)| (p, b.clone())));
     let clone2 = RoaringTreemap::from_iter(original.bitmaps().map(|(p, b)| (p, b.clone())));
 

--- a/tests/treemap_lib.rs
+++ b/tests/treemap_lib.rs
@@ -37,7 +37,18 @@ fn smoke() {
 
 #[test]
 fn remove_range() {
-    let ranges = [0u64, 1, 63, 64, 65, 100, 4096 - 1, 4096, 4096 + 1, 65536 - 1];
+    let ranges = [
+        0u64,
+        1,
+        63,
+        64,
+        65,
+        100,
+        4096 - 1,
+        4096,
+        4096 + 1,
+        65536 - 1,
+    ];
     for (i, &a) in ranges.iter().enumerate() {
         for &b in &ranges[i..] {
             let mut bitmap = RoaringTreemap::from_iter(0..=65536);
@@ -75,7 +86,7 @@ fn test_min() {
 fn to_bitmap() {
     let bitmap = RoaringTreemap::from_iter(0..5000);
     assert_eq!(bitmap.len(), 5000);
-    for i in 1..5000{
+    for i in 1..5000 {
         assert_eq!(bitmap.contains(i), true);
     }
     assert_eq!(bitmap.contains(5001), false);

--- a/tests/treemap_size_hint.rs
+++ b/tests/treemap_size_hint.rs
@@ -27,7 +27,11 @@ fn bitmap() {
 
 #[test]
 fn arrays() {
-    let bitmap = RoaringTreemap::from_iter((0..2000).chain(1_000_000..1_002_000).chain(2_000_000..2_001_000));
+    let bitmap = RoaringTreemap::from_iter(
+        (0..2000)
+            .chain(1_000_000..1_002_000)
+            .chain(2_000_000..2_001_000),
+    );
     let mut iter = bitmap.iter();
     assert_eq!((5000, Some(5000)), iter.size_hint());
     iter.by_ref().take(3000).for_each(drop);
@@ -38,7 +42,11 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let bitmap = RoaringTreemap::from_iter((0..6000).chain(1_000_000..1_012_000).chain(2_000_000..2_010_000));
+    let bitmap = RoaringTreemap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_012_000)
+            .chain(2_000_000..2_010_000),
+    );
     let mut iter = bitmap.iter();
     assert_eq!((28000, Some(28000)), iter.size_hint());
     iter.by_ref().take(2000).for_each(drop);

--- a/tests/treemap_symmetric_difference_with.rs
+++ b/tests/treemap_symmetric_difference_with.rs
@@ -81,9 +81,24 @@ fn bitmap_and_array_to_array() {
 
 #[test]
 fn arrays() {
-    let mut bitmap1 = RoaringTreemap::from_iter((0..2000).chain(1_000_000..1_002_000).chain(3_000_000..3_001_000));
-    let bitmap2 = RoaringTreemap::from_iter((1000..3000).chain(1_001_000..1_003_000).chain(2_000_000..2_000_001));
-    let bitmap3 = RoaringTreemap::from_iter((0..1000).chain(1_000_000..1_001_000).chain(2000..3000).chain(1_002_000..1_003_000).chain(2_000_000..2_000_001).chain(3_000_000..3_001_000));
+    let mut bitmap1 = RoaringTreemap::from_iter(
+        (0..2000)
+            .chain(1_000_000..1_002_000)
+            .chain(3_000_000..3_001_000),
+    );
+    let bitmap2 = RoaringTreemap::from_iter(
+        (1000..3000)
+            .chain(1_001_000..1_003_000)
+            .chain(2_000_000..2_000_001),
+    );
+    let bitmap3 = RoaringTreemap::from_iter(
+        (0..1000)
+            .chain(1_000_000..1_001_000)
+            .chain(2000..3000)
+            .chain(1_002_000..1_003_000)
+            .chain(2_000_000..2_000_001)
+            .chain(3_000_000..3_001_000),
+    );
 
     bitmap1.symmetric_difference_with(&bitmap2);
 
@@ -92,9 +107,24 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let mut bitmap1 = RoaringTreemap::from_iter((0..6000).chain(1_000_000..1_012_000).chain(3_000_000..3_010_000));
-    let bitmap2 = RoaringTreemap::from_iter((3000..7000).chain(1_006_000..1_018_000).chain(2_000_000..2_010_000));
-    let bitmap3 = RoaringTreemap::from_iter((0..3000).chain(1_000_000..1_006_000).chain(6000..7000).chain(1_012_000..1_018_000).chain(2_000_000..2_010_000).chain(3_000_000..3_010_000));
+    let mut bitmap1 = RoaringTreemap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_012_000)
+            .chain(3_000_000..3_010_000),
+    );
+    let bitmap2 = RoaringTreemap::from_iter(
+        (3000..7000)
+            .chain(1_006_000..1_018_000)
+            .chain(2_000_000..2_010_000),
+    );
+    let bitmap3 = RoaringTreemap::from_iter(
+        (0..3000)
+            .chain(1_000_000..1_006_000)
+            .chain(6000..7000)
+            .chain(1_012_000..1_018_000)
+            .chain(2_000_000..2_010_000)
+            .chain(3_000_000..3_010_000),
+    );
 
     bitmap1.symmetric_difference_with(&bitmap2);
 

--- a/tests/treemap_union_with.rs
+++ b/tests/treemap_union_with.rs
@@ -60,9 +60,22 @@ fn bitmap_and_array() {
 
 #[test]
 fn arrays() {
-    let mut bitmap1 = RoaringTreemap::from_iter((0..2000).chain(1_000_000..1_002_000).chain(3_000_000..3_001_000));
-    let bitmap2 = RoaringTreemap::from_iter((1000..3000).chain(1_001_000..1_003_000).chain(2_000_000..2_001_000));
-    let bitmap3 = RoaringTreemap::from_iter((0..3000).chain(1_000_000..1_003_000).chain(2_000_000..2_001_000).chain(3_000_000..3_001_000));
+    let mut bitmap1 = RoaringTreemap::from_iter(
+        (0..2000)
+            .chain(1_000_000..1_002_000)
+            .chain(3_000_000..3_001_000),
+    );
+    let bitmap2 = RoaringTreemap::from_iter(
+        (1000..3000)
+            .chain(1_001_000..1_003_000)
+            .chain(2_000_000..2_001_000),
+    );
+    let bitmap3 = RoaringTreemap::from_iter(
+        (0..3000)
+            .chain(1_000_000..1_003_000)
+            .chain(2_000_000..2_001_000)
+            .chain(3_000_000..3_001_000),
+    );
 
     bitmap1.union_with(&bitmap2);
 
@@ -71,9 +84,22 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let mut bitmap1 = RoaringTreemap::from_iter((0..6000).chain(1_000_000..1_012_000).chain(3_000_000..3_010_000));
-    let bitmap2 = RoaringTreemap::from_iter((3000..9000).chain(1_006_000..1_018_000).chain(2_000_000..2_010_000));
-    let bitmap3 = RoaringTreemap::from_iter((0..9000).chain(1_000_000..1_018_000).chain(2_000_000..2_010_000).chain(3_000_000..3_010_000));
+    let mut bitmap1 = RoaringTreemap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_012_000)
+            .chain(3_000_000..3_010_000),
+    );
+    let bitmap2 = RoaringTreemap::from_iter(
+        (3000..9000)
+            .chain(1_006_000..1_018_000)
+            .chain(2_000_000..2_010_000),
+    );
+    let bitmap3 = RoaringTreemap::from_iter(
+        (0..9000)
+            .chain(1_000_000..1_018_000)
+            .chain(2_000_000..2_010_000)
+            .chain(3_000_000..3_010_000),
+    );
 
     bitmap1.union_with(&bitmap2);
 

--- a/tests/union_with.rs
+++ b/tests/union_with.rs
@@ -60,9 +60,22 @@ fn bitmap_and_array() {
 
 #[test]
 fn arrays() {
-    let mut bitmap1 = RoaringBitmap::from_iter((0..2000).chain(1_000_000..1_002_000).chain(3_000_000..3_001_000));
-    let bitmap2 = RoaringBitmap::from_iter((1000..3000).chain(1_001_000..1_003_000).chain(2_000_000..2_001_000));
-    let bitmap3 = RoaringBitmap::from_iter((0..3000).chain(1_000_000..1_003_000).chain(2_000_000..2_001_000).chain(3_000_000..3_001_000));
+    let mut bitmap1 = RoaringBitmap::from_iter(
+        (0..2000)
+            .chain(1_000_000..1_002_000)
+            .chain(3_000_000..3_001_000),
+    );
+    let bitmap2 = RoaringBitmap::from_iter(
+        (1000..3000)
+            .chain(1_001_000..1_003_000)
+            .chain(2_000_000..2_001_000),
+    );
+    let bitmap3 = RoaringBitmap::from_iter(
+        (0..3000)
+            .chain(1_000_000..1_003_000)
+            .chain(2_000_000..2_001_000)
+            .chain(3_000_000..3_001_000),
+    );
 
     bitmap1.union_with(&bitmap2);
 
@@ -71,9 +84,22 @@ fn arrays() {
 
 #[test]
 fn bitmaps() {
-    let mut bitmap1 = RoaringBitmap::from_iter((0..6000).chain(1_000_000..1_012_000).chain(3_000_000..3_010_000));
-    let bitmap2 = RoaringBitmap::from_iter((3000..9000).chain(1_006_000..1_018_000).chain(2_000_000..2_010_000));
-    let bitmap3 = RoaringBitmap::from_iter((0..9000).chain(1_000_000..1_018_000).chain(2_000_000..2_010_000).chain(3_000_000..3_010_000));
+    let mut bitmap1 = RoaringBitmap::from_iter(
+        (0..6000)
+            .chain(1_000_000..1_012_000)
+            .chain(3_000_000..3_010_000),
+    );
+    let bitmap2 = RoaringBitmap::from_iter(
+        (3000..9000)
+            .chain(1_006_000..1_018_000)
+            .chain(2_000_000..2_010_000),
+    );
+    let bitmap3 = RoaringBitmap::from_iter(
+        (0..9000)
+            .chain(1_000_000..1_018_000)
+            .chain(2_000_000..2_010_000)
+            .chain(3_000_000..3_010_000),
+    );
 
     bitmap1.union_with(&bitmap2);
 


### PR DESCRIPTION
This PR formats the existing code with `cargo fmt` and then enables a check in CI to ensure it remains formatted.